### PR TITLE
Fix to referat specifications

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -421,7 +421,7 @@
       ]
   }
   pagebreak(weak: true)
-  heading(numbering: none)[#if text_lang == "en" [APPENDICES] else [PRILOGE]] 
+  heading(numbering: none, outlined: false)[#if text_lang == "en" [APPENDICES] else [PRILOGE]] 
 
   for name in priloge {
     align(left)[#if text_lang == "en" [Appendix] else [Priloga] #priloga_counter.display("A") #text(style: "italic", name.at(0))]

--- a/lib.typ
+++ b/lib.typ
@@ -86,7 +86,7 @@
 
   show footnote: it => text(size: 10pt, it)
   
-  set heading(numbering: "1.1")
+  set heading(numbering: "1.1   ")
 
   show heading.where(level: 1): it => text(size: 14pt, weight: "bold",upper(it))
   show heading.where(level: 2): it => text(size: 14pt, weight: "bold", it)

--- a/lib.typ
+++ b/lib.typ
@@ -87,10 +87,11 @@
   show footnote: it => text(size: 10pt, it)
   
   set heading(numbering: "1.1   ")
-
+  
   show heading: set block(spacing: 2em)
+
   show heading.where(level: 1): it => text(size: 14pt, weight: "bold",upper(it))
-  show heading.where(level: 2): it => text(size: 14pt, weight: "bold", it)
+  show heading.where(level: 2): it => text(size: 14pt, weight: "regular", upper(it))
   show heading.where(level: 3): it => text(size: 12pt, it)
   show heading.where(level: 4): it => text(size: 12pt, weight: "regular", it)
 
@@ -114,33 +115,33 @@
   
   // --------- COVER PAGE --------------
   if cover_page {
-  page(header: none, margin: (bottom: 5cm))[
-    #set text(size: 14pt, spacing: 0.28em)
-    #set align(center)
+    page(header: none, margin: (bottom: 5cm))[
+      #set text(size: 14pt, spacing: 0.28em)
+      #set align(center)
 
-    
-    UNIVERZA NA PRIMORSKEM\
-    FAKULTETA ZA MATEMATIKO, NARAVOSLOVJE IN\
-    INFORMACIJSKE TEHNOLOGIJE
+      
+      UNIVERZA NA PRIMORSKEM\
+      FAKULTETA ZA MATEMATIKO, NARAVOSLOVJE IN\
+      INFORMACIJSKE TEHNOLOGIJE
 
-    #align(center + horizon)[
-      ZAKLJUČNA NALOGA
+      #align(center + horizon)[
+        ZAKLJUČNA NALOGA
 
-      #if text_lang == "en" {
-        [(FINAL PROJECT PAPER)]
-      }
+        #if text_lang == "en" {
+          [(FINAL PROJECT PAPER)]
+        }
+      ]
+      #align(center + horizon)[
+        #set text(size: 18pt)
+        #upper(naslov)
+
+        #if text_lang == "en" {
+          [(#upper(title))]
+        }
+      ]
+      #set align(right + bottom)
+      #upper(author)
     ]
-    #align(center + horizon)[
-      #set text(size: 18pt)
-      #upper(naslov)
-
-      #if text_lang == "en" {
-        [(#upper(title))]
-      }
-    ]
-    #set align(right + bottom)
-    #upper(author)
-  ]
   }
   
   // --------- Header ---------------

--- a/lib.typ
+++ b/lib.typ
@@ -88,6 +88,7 @@
   
   set heading(numbering: "1.1   ")
 
+  show heading: set block(spacing: 2em)
   show heading.where(level: 1): it => text(size: 14pt, weight: "bold",upper(it))
   show heading.where(level: 2): it => text(size: 14pt, weight: "bold", it)
   show heading.where(level: 3): it => text(size: 12pt, it)

--- a/lib.typ
+++ b/lib.typ
@@ -336,9 +336,9 @@
   tablepage((target: heading, title: if text_lang =="sl" {"Kazalo vsebine"} else {"Table of contents"}))
   
 
-  tablepage((target: figure.where(kind: table), title: if text_lang == "sl" {"Kazalo preglednic"} else {"Index of tables"}))
+  tablepage((target: figure.where(kind: table), title: if text_lang == "sl" {"Kazalo preglednic"} else {"list of tables"}))
 
-  tablepage((target: figure.where(kind: image), title: if text_lang == "sl" {"Kazalo slik in grafikonov"} else {"Index of images and graphs"}))
+  tablepage((target: figure.where(kind: image), title: if text_lang == "sl" {"Kazalo slik in grafikonov"} else {"list of figures"}))
 
 
 

--- a/lib.typ
+++ b/lib.typ
@@ -419,7 +419,7 @@
       ]
   }
   set page(
-        header: align(right)[#if text_lang == "en" [Attachment] else [Priloga] #priloga_counter.display("A")],
+        header: align(left)[#if text_lang == "en" [Attachment] else [Priloga] #priloga_counter.display("A")],
         header-ascent: 1cm,
       )
   for name in priloge {

--- a/lib.typ
+++ b/lib.typ
@@ -424,7 +424,7 @@
   heading(numbering: none, outlined: false)[#if text_lang == "en" [APPENDICES] else [PRILOGE]] 
 
   for name in priloge {
-    align(left)[#if text_lang == "en" [Appendix] else [Priloga] #priloga_counter.display("A") #text(style: "italic", name.at(0))]
+    align(left)[#if text_lang == "en" {upper[Appendix]} else {upper[Priloga]} #priloga_counter.display("A") #text(style: "italic", name.at(0))]
     priloga(name)
     pagebreak(weak: true)
   }

--- a/lib.typ
+++ b/lib.typ
@@ -67,7 +67,7 @@
 
   // Displays the name with prepends and postpends
   let display_name(name, lang: "sl") = {
-    [#name.at(lang).at(0) #name.name #name.at(lang).at(1)]
+    [#name.at(lang).at(0)#name.name#name.at(lang).at(1)]
   }
   
   set page(
@@ -420,11 +420,11 @@
         #priloga_counter.step()
       ]
   }
-  set page(
-        header: align(left)[#if text_lang == "en" [Attachment] else [Priloga] #priloga_counter.display("A")],
-        header-ascent: 1cm,
-      )
+  pagebreak(weak: true)
+  heading(numbering: none)[#if text_lang == "en" [APPENDICES] else [PRILOGE]] 
+
   for name in priloge {
+    align(left)[#if text_lang == "en" [Appendix] else [Priloga] #priloga_counter.display("A") #text(style: "italic", name.at(0))]
     priloga(name)
     pagebreak(weak: true)
   }

--- a/lib.typ
+++ b/lib.typ
@@ -96,7 +96,7 @@
 
 
 
-
+  set outline(fill: repeat[.#h(8pt)], indent: 2em)
   show outline.where(target: selector(heading)): it => {
       show outline.entry.where(level: 1)
       .or(outline.entry.where(level: 2)): it => upper(it)

--- a/lib.typ
+++ b/lib.typ
@@ -184,7 +184,7 @@
   
   // ---- Ključna dokumentacija ----
   page()[
-    #h(1fr)*Ključna dokumentacijska informacija*
+    *Ključna dokumentacijska informacija*
     
     #box(
       stroke: black + 0.5pt,
@@ -241,7 +241,7 @@
   // ---- Ključna dokumentacija (eng)----
 
   page()[
-    #h(1fr)*Key document information*
+    *Key document information*
     
     #box(
       stroke: black + 0.5pt,

--- a/lib.typ
+++ b/lib.typ
@@ -353,7 +353,7 @@
     title: if text_lang == "sl" {
       "Kazalo prilog"
     } else {
-      "Index of Attachments"
+      "List of Appendices"
     },
   ))
   
@@ -410,7 +410,7 @@
     
       [
         #figure(
-          supplement: if text_lang == "en" [Attachment] else [Priloga],
+          supplement: if text_lang == "en" [Appendix] else [Priloga],
           kind: "Priloga",
           numbering: "A",
           caption: text( style: "italic", content.at(0)),

--- a/lib.typ
+++ b/lib.typ
@@ -92,6 +92,17 @@
   show heading.where(level: 2): it => text(size: 14pt, weight: "bold", it)
   show heading.where(level: 3): it => text(size: 12pt, it)
   show heading.where(level: 4): it => text(size: 12pt, weight: "regular", it)
+
+
+
+
+  show outline.where(target: selector(heading)): it => {
+      show outline.entry.where(level: 1)
+      .or(outline.entry.where(level: 2)): it => upper(it)
+      it
+  }
+
+
   
   show figure.caption: it => text(size: 10pt,it)
 

--- a/lib.typ
+++ b/lib.typ
@@ -45,6 +45,7 @@
   priloge: (),
   bib_file: none,
   text_lang: "sl",
+  cover_page: true,
   body,
 ) = {
   let auth_dict = split_author(author)
@@ -99,6 +100,7 @@
   
   
   // --------- COVER PAGE --------------
+  if cover_page {
   page(header: none, margin: (bottom: 5cm))[
     #set text(size: 14pt, spacing: 0.28em)
     #set align(center)
@@ -126,6 +128,7 @@
     #set align(right + bottom)
     #upper(author)
   ]
+  }
   
   // --------- Header ---------------
   page(header:none)[

--- a/lib.typ
+++ b/lib.typ
@@ -164,14 +164,7 @@
     #counter(page).update(1)
   ]
 
-  // ----------- zahala -----------------
-  if zahvala != none {
-    page()[
-      #text(weight: "bold", size: 18pt, if text_lang == "en" [Acknowledgement] else [Zahvala])
 
-      #zahvala
-    ]
-  }
   let item_counter(target, prefix) = context {
     let cnt = counter(target).final().first()
     if cnt > 0 {
@@ -301,6 +294,15 @@
       
     ]
   ]
+  
+  // ----------- zahala -----------------
+  if zahvala != none {
+    page()[
+      #text(weight: "bold", size: 18pt, if text_lang == "en" [Acknowledgement] else [Zahvala])
+
+      #zahvala
+    ]
+  }
 
   // -------- TABLES ----------
 

--- a/lib.typ
+++ b/lib.typ
@@ -105,6 +105,7 @@
 
   
   show figure.caption: it => text(size: 10pt,it)
+  show figure.where(kind: table): set figure.caption(position: top)
 
   show bibliography: set heading(numbering: "1.1")
   

--- a/lib.typ
+++ b/lib.typ
@@ -59,7 +59,7 @@
     #v(1.5cm)
     
     #surname_i(author) #naslov.\
-    Univerza na Primorskem, Fakulteta za matematiko, naravoslovje in informacijske tehnologije,#date.year()
+    Univerza na Primorskem, Fakulteta za matematiko, naravoslovje in informacijske tehnologije, #date.year()
     #h(1fr)
     #counter(page).display(dsp)
     #line(start: (0pt,-6pt), length: 100%, stroke: col.gray + 0.5pt)

--- a/lib.typ
+++ b/lib.typ
@@ -421,6 +421,7 @@
       ]
   }
   pagebreak(weak: true)
+  set page(header: none)
   heading(numbering: none, outlined: false)[#if text_lang == "en" [APPENDICES] else [PRILOGE]] 
 
   for name in priloge {


### PR DESCRIPTION
This commit changes the template to fit the referat specifications
 It changes:
- [x] remove cover page
- [x] acknowledgment after PKI info
- [x] PKI title to the left side
- [x] TITLES and subtitles (headings) with capital letters v TOC
   - [x]  make titles and subtitles upper
   - [x] make indented TOC
- [x] empty space after titles and subtitles
- [x] add space between numbering and titles/subtitles(headings)
- [x] table caption should be above fig
- [x] attachment title on the left
